### PR TITLE
Selene example config generation

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,20 +1,22 @@
 {
   "tasks": {
     // build
-    "build": "deno task build-slua-defs && deno task build-slua-docs && deno task build-slua-sele && deno task build-lsl-json && deno task build-slua-json",
+    "build": "deno task build-slua-defs && deno task build-slua-docs && deno task build-slua-sele && deno task build-slua-sele-config && deno task build-lsl-json && deno task build-slua-json",
     "build-slua-defs": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-defs > dist/ll.d.luau",
     "build-slua-sele": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-sele > dist/sl_selene_defs.yml",
+    "build-slua-sele-config": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-sele-config > dist/selene.toml",
     "build-slua-docs": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-docs > dist/ll.d.json",
     "build-slua-json": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-json > dist/slua_keywords.json",
     "build-lsl-json": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml lsl-json > dist/lsl_keywords.json",
     "generate-markdown": "deno run -R -W -E src/main.ts ./data/keywords_lsl_formatted.llsd.xml slua-markdown docs/output docs/html",
     // build and install
     "install": "deno task build && deno task copy-to-install",
-    "copy-to-install" : "mkdir -p $HOME/.sl-luau && cp ./dist/* $HOME/.sl-luau/.",
+    "copy-to-install": "mkdir -p $HOME/.sl-luau && cp ./dist/* $HOME/.sl-luau/.",
     // Download version
     "build-dl": "deno task build-defs-dl && deno task build-docs-dl && deno task build-sele-dl && deno task build-json-dl",
     "build-slua-defs-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-defs > dist/ll.d.luau",
     "build-slua-sele-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-sele > dist/sl_selene_defs.yml",
+    "build-slua-sele-config-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-sele-config > dist/selene.toml",
     "build-slua-docs-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-docs > dist/ll.d.json",
     "build-slua-json-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-json > dist/slua_keywords.json",
     "build-lsl-json-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml lsl-json > dist/lsl_keywords.json",

--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@libs/xml@*": "6.0.4",
     "jsr:@maxim-mazurok/sax-ts@*": "1.2.13",
     "jsr:@std/bytes@^1.0.5": "1.0.5",
+    "jsr:@std/collections@^1.0.10": "1.0.10",
     "jsr:@std/encoding@*": "1.0.7",
     "jsr:@std/encoding@1": "1.0.7",
     "jsr:@std/fs@*": "1.0.14",
@@ -12,6 +13,7 @@
     "jsr:@std/path@*": "1.0.8",
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/streams@*": "1.0.9",
+    "jsr:@std/toml@*": "1.0.3",
     "jsr:@std/yaml@*": "1.0.5",
     "jsr:@takker/md5@*": "0.1.0"
   },
@@ -27,6 +29,9 @@
     },
     "@std/bytes@1.0.5": {
       "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+    },
+    "@std/collections@1.0.10": {
+      "integrity": "903af106a3d92970d74e20f7ebff77d9658af9bef4403f1dc42a7801c0575899"
     },
     "@std/encoding@1.0.7": {
       "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
@@ -47,6 +52,12 @@
       "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
       "dependencies": [
         "jsr:@std/bytes"
+      ]
+    },
+    "@std/toml@1.0.3": {
+      "integrity": "dd5c039860a312779ec19980be000d977ce8f56fadaa073d8f33632f21540ffb",
+      "dependencies": [
+        "jsr:@std/collections"
       ]
     },
     "@std/yaml@1.0.5": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { buildSluaDocs } from "./slua/slua-docs-gen.ts";
 import { buildSluaJson } from "./slua/slua-json-gen.ts";
 import { generateSLuaMarkdown } from "./slua/slua-md-gen.ts";
 import { buildSluaSelene } from "./slua/slua-sele-gen.ts";
+import { buildSluaSeleneConfig } from "./slua/slua-sele-conf-gen.ts";
 
 const keywordsFile = Deno.args[0];
 const output = Deno.args[1];
@@ -26,6 +27,9 @@ switch (output) {
     break;
   case "slua-sele":
     console.log(await buildSluaSelene(keywordsFile));
+    break;
+  case "slua-sele-config":
+    console.log(await buildSluaSeleneConfig(keywordsFile));
     break;
   case "slua-markdown":
     await generateSLuaMarkdown(keywordsFile, Deno.args[2], Deno.args[3]);

--- a/src/slua/slua-sele-conf-gen.ts
+++ b/src/slua/slua-sele-conf-gen.ts
@@ -1,0 +1,54 @@
+import { stringify } from "jsr:@std/toml";
+import { buildSluaJson } from "./slua-json-gen.ts";
+
+type SeleneConfig = {
+  std: string;
+
+  rules: {
+    global_usage: string;
+    shadowing: string;
+    must_use: string;
+  };
+
+  config: {
+    empty_if: {
+      comments_count: boolean;
+    };
+
+    unused_variable: {
+      ignore_pattern: string;
+    };
+  };
+};
+
+export async function buildSluaSeleneConfig(
+  file: string,
+  strict: boolean = true,
+): Promise<string> {
+  const data = await buildSluaJson(file, strict);
+
+  const eventNames = Object.entries(data.global.props)
+    .filter(([_, prop]) => prop.def === "event")
+    .map(([name]) => name);
+
+  const ignorePattern = eventNames.map((name) => `^${name}$`).join("|");
+
+  const seleneConfig: SeleneConfig = {
+    std: "sl_selene_defs",
+    rules: {
+      global_usage: "allow",
+      shadowing: "allow",
+      must_use: "warn",
+    },
+    config: {
+      empty_if: {
+        comments_count: true,
+      },
+      unused_variable: {
+        ignore_pattern: ignorePattern,
+      },
+    },
+  };
+
+  return stringify(seleneConfig);
+}


### PR DESCRIPTION
Creates an example `selene.toml` config file with all known events ignored under `unused_variable`.

```toml
std = "sl_selene_defs"

[rules]
global_usage = "allow"
shadowing = "allow"
must_use = "warn"

[config.empty_if]
comments_count = true

[config.unused_variable]
ignore_pattern = "^at_rot_target$|^at_target$|^attac...
```

Might be able to remove this later, if we see changes to the event APIs.