### PR TITLE
VSCode snippet generation

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,8 +1,9 @@
 {
   "tasks": {
     // build
-    "build": "deno task build-slua-defs && deno task build-slua-docs && deno task build-slua-sele && deno task build-lsl-json && deno task build-slua-json",
+    "build": "deno task build-slua-defs && deno task build-slua-docs && deno task build-slua-vsc-snippets && deno task build-slua-sele && deno task build-lsl-json && deno task build-slua-json",
     "build-slua-defs": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-defs > dist/ll.d.luau",
+    "build-slua-vsc-snippets": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-vsc-snippets > dist/luau.code-snippets",
     "build-slua-sele": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-sele > dist/sl_selene_defs.yml",
     "build-slua-docs": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-docs > dist/ll.d.json",
     "build-slua-json": "deno -R -E src/main.ts data/keywords_lsl_formatted.llsd.xml slua-json > dist/slua_keywords.json",
@@ -10,7 +11,7 @@
     "generate-markdown": "deno run -R -W -E src/main.ts ./data/keywords_lsl_formatted.llsd.xml slua-markdown docs/output docs/html",
     // build and install
     "install": "deno task build && deno task copy-to-install",
-    "copy-to-install" : "mkdir -p $HOME/.sl-luau && cp ./dist/* $HOME/.sl-luau/.",
+    "copy-to-install": "mkdir -p $HOME/.sl-luau && cp ./dist/* $HOME/.sl-luau/.",
     // Download version
     "build-dl": "deno task build-defs-dl && deno task build-docs-dl && deno task build-sele-dl && deno task build-json-dl",
     "build-slua-defs-dl": "deno -R src/main.ts data/keywords_lsl_download.llsd.xml slua-defs > dist/ll.d.luau",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { buildSluaDocs } from "./slua/slua-docs-gen.ts";
 import { buildSluaJson } from "./slua/slua-json-gen.ts";
 import { generateSLuaMarkdown } from "./slua/slua-md-gen.ts";
 import { buildSluaSelene } from "./slua/slua-sele-gen.ts";
+import { buildSluaVSCodeSnippets } from "./slua/slua-vsc-snippets-gen.ts";
 
 const keywordsFile = Deno.args[0];
 const output = Deno.args[1];
@@ -23,6 +24,9 @@ switch (output) {
     break;
   case "slua-docs":
     console.log(JSON.stringify(await buildSluaDocs(keywordsFile), null, 2));
+    break;
+  case "slua-vsc-snippets":
+    console.log(await buildSluaVSCodeSnippets(keywordsFile));
     break;
   case "slua-sele":
     console.log(await buildSluaSelene(keywordsFile));

--- a/src/slua/slua-vsc-snippets-gen.ts
+++ b/src/slua/slua-vsc-snippets-gen.ts
@@ -25,7 +25,7 @@ export async function buildSluaVSCodeSnippets(
       
       snippets[name] = {
         scope: "luau",
-        prefix: name,
+        prefix: `function ${name}`,
         body: [functionSignature],
         description: prop.desc ?? `Triggered when ${name} occurs.`
       };

--- a/src/slua/slua-vsc-snippets-gen.ts
+++ b/src/slua/slua-vsc-snippets-gen.ts
@@ -1,0 +1,60 @@
+import { buildSluaJson, SLuaFuncArg } from "./slua-json-gen.ts";
+
+type VSCodeSnippet = {
+  scope: string;
+  prefix: string;
+  body: string[];
+  description: string;
+};
+
+type VSCodeSnippets = {
+  [key: string]: VSCodeSnippet;
+};
+
+export async function buildSluaVSCodeSnippets(
+  file: string,
+  strict: boolean = true,
+): Promise<string> {
+  const data = await buildSluaJson(file, strict);
+  const snippets: VSCodeSnippets = {};
+
+  for (const [name, prop] of Object.entries(data.global.props)) {
+    if (prop.def === "event") {
+      const args = prop.args?.map(formatArg).join(", ") ?? "";
+      const functionSignature = `function ${name}(${args})`;
+      
+      snippets[name] = {
+        scope: "luau",
+        prefix: name,
+        body: [functionSignature],
+        description: prop.desc ?? `Triggered when ${name} occurs.`
+      };
+    }
+  }
+
+  return JSON.stringify(snippets, null, 2);
+}
+
+function formatArg(arg: SLuaFuncArg): string {
+  const name = arg.name.replace(/(?<!^)([A-Z][a-z]+)/g, "_$1").toLowerCase();
+  const type = arg.type.map(t => t).join(" | ");
+
+  return `${simplifyName(name)}: ${type}`;
+}
+
+function simplifyName(name: string): string {
+  switch (true) {
+    case name.endsWith("id"):
+      return "id";
+    case name.startsWith("number_of_"):
+      return name.replace("number_of_", "");
+    case name.startsWith("http_"):
+      return name.replace("http_", "");
+    case name.startsWith("start_"):
+      return name.replace("start_", "");
+    case name.startsWith("senders_"):
+      return name.replace("senders_", "");
+    default:
+      return name;
+  }
+}


### PR DESCRIPTION
Creates `luau.code-snippets` file that can be added to `.vscode` to add typed auto-complete for event functions. Feels a little less clunky compared to what the LSP gives us from globals.

```json
"attach": {
  "scope": "luau",
  "prefix": "function attach",
  "body": [
    "function attach(id: uuid | string)"
  ],
  "description": "This event is triggered whenever an object is attached or detached from an avatar. If it is attached, the key of the avatar it is attached to is passed in, otherwise NULL_KEY is."
},
```

![CleanShot 2025-04-04 at 10  55 59](https://github.com/user-attachments/assets/9daf1d77-ec5a-4df1-a8fe-4c9c75c5c77c)
